### PR TITLE
Fix index.md english and word reuse

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,14 @@
 Invisible Internet Protocol (daemon)
 ====================================
 
-i2pd (I2P Daemon) is a full-featured C++ implementation of I2P client.
+i2pd (I2P Daemon) is a fully-featured C++ implementation of the I2P protocol.
 
 I2P (Invisible Internet Protocol) is a universal anonymous network layer. 
-All communications over I2P are anonymous and end-to-end encrypted, participants
+All communications over I2P are anonymous and end-to-end encrypted, and participants
 don't reveal their real IP addresses. 
 
-I2P client is a software used for building and using anonymous I2P 
-networks. Such networks are commonly used for anonymous peer-to-peer 
+An I2P client is an application for building and traversing anonymous I2P 
+networks. Such networks are commonly used for both anonymous peer-to-peer 
 applications (filesharing, cryptocurrencies) and anonymous client-server 
 applications (websites, instant messengers, chat-servers).
 


### PR DESCRIPTION
Some terminology was wrong, and some articles/conjunctions were missing.

I'm not sure why the other commits of mine were reverted, but this one should clearly stay.