### PR TITLE
Replace deprecated I2P-Transmission client

### DIFF
--- a/docs/tutorials/filesharing.md
+++ b/docs/tutorials/filesharing.md
@@ -1,7 +1,7 @@
 Anonymous filesharing
 =====================
 
-You can share and download torrents with [Transmission-I2P](https://github.com/l-n-s/transmission-i2p).
+You can share and download torrents with [XD](https://github.com/majestrate/XD).
 
 Alternative torrent-clients are [Robert](http://en.wikipedia.org/wiki/Robert_%28P2P_Software%29) and [Vuze](https://en.wikipedia.org/wiki/Vuze).
 


### PR DESCRIPTION
The [I2P-Transmission client](https://github.com/l-n-s/transmission-i2p) received its last update in January 2018. The repo states it is unmaintained and one should use [XD](https://github.com/majestrate/XD) instead.