### PR TITLE
Add Monero over I2P tutorial link to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
     - Anonymous websites: tutorials/http.md
     - Anonymous IRC chats: tutorials/irc.md
     - Decentralized instant messenger (XMPP aka Jabber): tutorials/xmpp.md
+    - Monero over I2P: tutorials/Monero.md
     - Filesharing: 
         - Software: tutorials/Filesharing/Software.md
         - qBittorrent: tutorials/Filesharing/qBittorrent.md


### PR DESCRIPTION
Just added my tutorial to the side bay, as it wasn't there and it made me feel sad